### PR TITLE
Info should not override secretKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,20 +170,13 @@ module.exports = class Omega extends EventEmitter {
       this.options = { ...this.options, ...(await this.options.preload()) }
     }
 
-    let secretKey = null
-
-    if (this.options.keyPair) {
-      this.key = this.options.keyPair.publicKey
-      secretKey = this.options.keyPair.secretKey
-    }
-
     this.info = await Info.open(this.storage('info'), {
       crypto: this.crypto,
       publicKey: this.key,
-      secretKey
+      ...this.options.keyPair
     })
     this.key = this.info.publicKey
-    secretKey = this.info.secretKey
+    const secretKey = this.info.secretKey
     const fork = this.info.fork
 
     this.replicator = new Replicator(this)

--- a/lib/info.js
+++ b/lib/info.js
@@ -1,7 +1,7 @@
 const uint64le = require('uint64le')
 
 module.exports = class Info {
-  constructor (storage, opts) {
+  constructor (storage) {
     this.storage = storage
     this.secretKey = null
     this.publicKey = null
@@ -13,18 +13,15 @@ module.exports = class Info {
     if (!this.publicKey) {
       if (publicKey) {
         this.publicKey = publicKey
-        this.secretKey = secretKey
+        this.secretKey = secretKey || null
       } else {
         const keys = crypto.keyPair()
         this.publicKey = keys.publicKey
         this.secretKey = keys.secretKey
       }
       await this.flush()
-    } else {
-      if (publicKey && !this.publicKey.equals(publicKey)) {
-        throw new Error('Another hypercore is stored here')
-      }
-      this.key = this.info.publicKey
+    } else if (publicKey && !this.publicKey.equals(publicKey)) {
+      throw new Error('Another hypercore is stored here')
     }
   }
 


### PR DESCRIPTION
If a `keyPair` is set by the `preload` option, then the `Info` should not override it.

*Edit: Instead of overriding info, I added an options to Info so that it supports other values that might be passed in through `preload`. Right now only `secretKey`.*