### PR TITLE
Update range indexes before reassigning array elements in replicator

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -166,6 +166,7 @@ class Range {
   _done (err, done) {
     if (!this._ranges) return
 
+    this._ranges[this._ranges.length - 1]._index = this._index
     this._ranges[this._index] = this._ranges[this._ranges.length - 1]
     this._ranges.pop()
     this._ranges = null


### PR DESCRIPTION
hyperbee.createReadStream() triggered an error caused by iterating over the RequestPool's ranges due to undefined elements.

This was because the index used to update the range elements on L169 was out of bounds