### PR TITLE
make keypair optional for later static cores and persist tree hash in header

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -81,6 +81,7 @@ module.exports = class Core {
           type: 'BLAKE2b',
           fork: 0,
           length: 0,
+          rootHash: null,
           signature: null
         },
         reorgs: [],
@@ -135,6 +136,7 @@ module.exports = class Core {
 
         header.tree.length = tree.length
         header.tree.fork = tree.fork
+        header.tree.rootHash = tree.hash()
         header.tree.signature = tree.signature
       }
     }
@@ -215,7 +217,9 @@ module.exports = class Core {
 
       const batch = this.tree.batch()
       for (const val of values) batch.append(val)
-      batch.signature = await sign(batch.signable())
+
+      const hash = batch.hash()
+      batch.signature = await sign(batch.signable(hash))
 
       const entry = {
         userData: null,
@@ -235,6 +239,7 @@ module.exports = class Core {
       batch.commit()
 
       this.header.tree.length = batch.length
+      this.header.tree.rootHash = hash
       this.header.tree.signature = batch.signature
       this.onupdate(0b01, entry.bitfield, null, null)
 
@@ -248,7 +253,8 @@ module.exports = class Core {
 
   async _verifyExclusive ({ batch, bitfield, value, from }) {
     // TODO: move this to tree.js
-    if (!batch.signature || !this.crypto.verify(batch.signable(), batch.signature, this.header.keyPair.publicKey)) {
+    const hash = batch.hash()
+    if (!batch.signature || !this.crypto.verify(batch.signable(hash), batch.signature, this.header.keyPair.publicKey)) {
       throw new Error('Remote signature does not match')
     }
 
@@ -273,6 +279,7 @@ module.exports = class Core {
 
       this.header.tree.fork = batch.fork
       this.header.tree.length = batch.length
+      this.header.tree.rootHash = batch.rootHash
       this.header.tree.signature = batch.signature
       this.onupdate(0b01, bitfield, value, from)
 
@@ -405,6 +412,7 @@ module.exports = class Core {
 
     this.header.tree.fork = batch.fork
     this.header.tree.length = batch.length
+    this.header.tree.rootHash = batch.hash()
     this.header.tree.signature = batch.signature
     this.onupdate(appended ? 0b11 : 0b10, entry.bitfield, null, from)
 

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -56,8 +56,8 @@ class MerkleTreeBatch {
     return this.tree.crypto.tree(this.roots)
   }
 
-  signable () {
-    return signable(this.hash(), this.length, this.fork)
+  signable (hash = this.hash()) {
+    return signable(hash, this.length, this.fork)
   }
 
   signedBy (key) {
@@ -366,8 +366,8 @@ module.exports = class MerkleTree extends Flushable {
     return this.crypto.tree(this.roots)
   }
 
-  signable () {
-    return signable(this.hash(), this.length, this.fork)
+  signable (hash = this.hash()) {
+    return signable(hash, this.length, this.fork)
   }
 
   signedBy (key) {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -453,12 +453,14 @@ const treeHeader = {
     c.string.preencode(state, t.type)
     c.uint.preencode(state, t.fork)
     c.uint.preencode(state, t.length)
+    c.buffer.preencode(state, t.rootHash)
     c.buffer.preencode(state, t.signature)
   },
   encode (state, t) {
     c.string.encode(state, t.type)
     c.uint.encode(state, t.fork)
     c.uint.encode(state, t.length)
+    c.buffer.encode(state, t.rootHash)
     c.buffer.encode(state, t.signature)
   },
   decode (state) {
@@ -466,6 +468,7 @@ const treeHeader = {
       type: c.string.decode(state),
       fork: c.uint.decode(state),
       length: c.uint.decode(state),
+      rootHash: c.buffer.decode(state),
       signature: c.buffer.decode(state)
     }
   }
@@ -519,16 +522,16 @@ exports.oplogHeader = {
   },
   encode (state, h) {
     state.buffer[state.start++] = 0 // version
-    state.buffer[state.start++] = 0 // flags (none for now)
+    state.buffer[state.start++] = h.keyPair ? 1 : 0
     keyValueArray.encode(state, h.userData)
-    keyPair.encode(state, h.keyPair)
+    if (h.keyPair) keyPair.encode(state, h.keyPair)
     treeHeader.encode(state, h.tree)
     reorgArray.encode(state, h.reorgs)
     bitfieldHeader.encode(state, h.bitfield)
   },
   decode (state) {
     const version = c.uint.decode(state)
-    c.uint.decode(state) // flags, unused atm
+    const flags = c.uint.decode(state)
 
     if (version !== 0) {
       throw new Error('Invalid header version. Expected 0, got ' + version)
@@ -536,7 +539,7 @@ exports.oplogHeader = {
 
     return {
       userData: keyValueArray.decode(state),
-      keyPair: keyPair.decode(state),
+      keyPair: (flags & 1 === 0) ? null : keyPair.decode(state),
       tree: treeHeader.decode(state),
       reorgs: reorgArray.decode(state),
       bitfield: bitfieldHeader.decode(state)


### PR DESCRIPTION
This is a minor breaking change that'll

1. Make the key pair field optional in the header. This allows a) to make a breaking change later (doubt we will) b) more importantly to support static cores easily later on (ie no keypair -> static core)
2. Always persist the tree hash in the header. This has negligle overhead (we are writing 32 bytes more on each upgrade, benchs showed no diff), but always static cores easily and to more easily do audits in the future, as the header is fully self describing.

By self describing we mean:

Has rootHash, length, fork and signature. From there we can checkout and verify the full stored merkle tree. From there we can verify which data blocks we have fully and from there we can generate the bitfield we have.