### PR TITLE
Expose header.userData through getter/setter/constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,10 +210,16 @@ module.exports = class Hypercore extends EventEmitter {
     if (!this.storage) this.storage = defaultStorage(opts.storage || storage)
 
     this.core = await Core.open(this.storage, {
-      crypto: this.crypto,
       keyPair,
+      crypto: this.crypto,
       onupdate: this._oncoreupdate.bind(this)
     })
+
+    if (opts.userData) {
+      for (const [key, value] of Object.entries(opts.userData)) {
+        await this.core.userData(key, value)
+      }
+    }
 
     this.replicator = new Replicator(this.core, {
       onupdate: this._onpeerupdate.bind(this)

--- a/lib/core.js
+++ b/lib/core.js
@@ -74,7 +74,7 @@ module.exports = class Core {
 
       header = {
         types: { tree: 'blake2b', bitfield: 'raw', signer: 'ed25519' },
-        userData: opts.userData || [],
+        userData: [],
         tree: {
           fork: 0,
           length: 0,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "random-access-memory": "^3.1.2",
     "range-parser": "^1.2.1",
     "standard": "^16.0.3",
-    "tape": "^5.0.1"
+    "tape": "^5.0.1",
+    "tmp-promise": "^3.0.2"
   },
   "optionalDependencies": {
     "fsctl": "^1.0.0"

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,7 @@
 const tape = require('tape')
 const ram = require('random-access-memory')
 const crypto = require('hypercore-crypto')
+const tmp = require('tmp-promise')
 
 const Hypercore = require('..')
 const { create } = require('./helpers')
@@ -125,5 +126,48 @@ tape('preload - sign/storage', async function (t) {
   t.same(core.length, 1)
   t.same(await core.get(0), 'hello world')
 
+  t.end()
+})
+
+tape('userdata - can set through setUserData', async function (t) {
+  const core = await create()
+  await core.setUserData('hello', Buffer.from('world'))
+
+  t.same(await core.getUserData('hello'), Buffer.from('world'))
+
+  t.end()
+})
+
+tape('userdata - can set through constructor option', async function (t) {
+  const core = await create({
+    userData: {
+      hello: Buffer.from('world')
+    }
+  })
+
+  t.same(await core.getUserData('hello'), Buffer.from('world'))
+
+  t.end()
+})
+
+tape('userdata - persists across restarts', async function (t) {
+  const dir = await tmp.dir()
+
+  let core = new Hypercore(dir.path, {
+    userData: {
+      hello: Buffer.from('world')
+    }
+  })
+  await core.ready()
+
+  await core.close()
+  core = new Hypercore(dir.path, {
+    userData: {
+      other: Buffer.from('another')
+    }
+  })
+
+  t.same(await core.getUserData('hello'), Buffer.from('world'))
+  t.same(await core.getUserData('other'), Buffer.from('another'))
   t.end()
 })


### PR DESCRIPTION
Adds support for getting/setting KV records in the header's `userData` field through both a constructor option, and the new `getUserData` and `setUserData` methods.

Also adds the `tmp-promise` dependency, as this PR adds a test for persistent behavior (where a Hypercore is reopened).