### PR TITLE
Add support for postload option

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,8 @@ module.exports = class Hypercore extends EventEmitter {
     this.extensions.attach(this.replicator)
     this.opened = true
 
+    if (opts.postload) await opts.postload(this)
+
     for (let i = 0; i < this.sessions.length; i++) {
       const s = this.sessions[i]
       if (s !== this) s._initSession(this)


### PR DESCRIPTION
In Corestore, we store a core's name/namespace (used for key generation) in Hypercore's new `userData` header field.

If you first create a core by name (i.e. `corestore.get({ name: 'main' })`), then you close/reopen the store, and then get it by public key (i.e. `corestore.get(key)`), the core will not be writable, since the `name` is the write capability.

With this change, Corestore can attempt to load a name/namespace and do key generation during `Hypercore.open`, so the `name` is no longer the write capability.