### PR TITLE
userData function must always release mutex

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -171,18 +171,18 @@ module.exports = class Core {
     // to just hitch a ride on one of the other ongoing appends?
     await this._mutex.lock()
 
-    let empty = true
-
-    for (const u of this.header.userData) {
-      if (u.key !== key) continue
-      if (value && u.value.equals(value)) return
-      empty = false
-      break
-    }
-
-    if (empty && !value) return
-
     try {
+      let empty = true
+
+      for (const u of this.header.userData) {
+        if (u.key !== key) continue
+        if (value && u.value.equals(value)) return
+        empty = false
+        break
+      }
+
+      if (empty && !value) return
+
       const entry = {
         userData: { key, value },
         treeNodes: null,


### PR DESCRIPTION
If the `userData` function on `lib/core.js` exits early, it currently doesn't release the mutex. It should always release the mutex.