### PR TITLE
Align flag encoding in messages

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -88,9 +88,7 @@ const dataBlock = {
 exports.data = {
   preencode (state, d) {
     c.uint.preencode(state, d.fork)
-
-    state.end++
-
+    state.end++ // flags
     if (d.block) dataBlock.preencode(state, d.block)
     if (d.seek) dataSeek.preencode(state, d.seek)
     if (d.upgrade) dataUpgrade.preencode(state, d.upgrade)
@@ -99,32 +97,31 @@ exports.data = {
     c.uint.encode(state, d.fork)
 
     const s = state.start++
-    let bits = 0
+    let flags = 0
 
     if (d.block) {
-      bits |= 1
+      flags |= 1
       dataBlock.encode(state, d.block)
     }
     if (d.seek) {
-      bits |= 2
+      flags |= 2
       dataSeek.encode(state, d.seek)
     }
     if (d.upgrade) {
-      bits |= 4
+      flags |= 4
       dataUpgrade.encode(state, d.upgrade)
     }
 
-    state.buffer[s] = bits
+    state.buffer[s] = flags
   },
   decode (state) {
     const fork = c.uint.decode(state)
-    const bits = c.uint.decode(state)
-
+    const flags = c.uint.decode(state)
     return {
       fork,
-      block: (bits & 1) === 0 ? null : dataBlock.decode(state),
-      seek: (bits & 2) === 0 ? null : dataSeek.decode(state),
-      upgrade: (bits & 4) === 0 ? null : dataUpgrade.decode(state)
+      block: (flags & 1) === 0 ? null : dataBlock.decode(state),
+      seek: (flags & 2) === 0 ? null : dataSeek.decode(state),
+      upgrade: (flags & 4) === 0 ? null : dataUpgrade.decode(state)
     }
   }
 }
@@ -183,9 +180,7 @@ const requestUpgrade = {
 exports.request = {
   preencode (state, r) {
     c.uint.preencode(state, r.fork)
-
-    state.end++
-
+    state.end++ // flags
     if (r.block) requestBlock.preencode(state, r.block)
     if (r.seek) requestSeek.preencode(state, r.seek)
     if (r.upgrade) requestUpgrade.preencode(state, r.upgrade)
@@ -194,32 +189,31 @@ exports.request = {
     c.uint.encode(state, r.fork)
 
     const s = state.start++
-    let bits = 0
+    let flags = 0
 
     if (r.block) {
-      bits |= 1
+      flags |= 1
       requestBlock.encode(state, r.block)
     }
     if (r.seek) {
-      bits |= 2
+      flags |= 2
       requestSeek.encode(state, r.seek)
     }
     if (r.upgrade) {
-      bits |= 4
+      flags |= 4
       requestUpgrade.encode(state, r.upgrade)
     }
 
-    state.buffer[s] = bits
+    state.buffer[s] = flags
   },
   decode (state) {
     const fork = c.uint.decode(state)
-    const bits = c.uint.decode(state)
-
+    const flags = c.uint.decode(state)
     return {
       fork,
-      block: (bits & 1) === 0 ? null : requestBlock.decode(state),
-      seek: (bits & 2) === 0 ? null : requestSeek.decode(state),
-      upgrade: (bits & 4) === 0 ? null : requestUpgrade.decode(state)
+      block: (flags & 1) === 0 ? null : requestBlock.decode(state),
+      seek: (flags & 2) === 0 ? null : requestSeek.decode(state),
+      upgrade: (flags & 4) === 0 ? null : requestUpgrade.decode(state)
     }
   }
 }
@@ -411,11 +405,27 @@ exports.oplogEntry = {
     if (m.bitfield) bitfieldUpdate.preencode(state, m.bitfield)
   },
   encode (state, m) {
-    state.buffer[state.start++] = (m.userData ? 1 : 0) | (m.treeNodes ? 2 : 0) | (m.treeUpgrade ? 4 : 0) | (m.bitfield ? 8 : 0)
-    if (m.userData) keyValue.encode(state, m.userData)
-    if (m.treeNodes) nodeArray.encode(state, m.treeNodes)
-    if (m.treeUpgrade) treeUpgrade.encode(state, m.treeUpgrade)
-    if (m.bitfield) bitfieldUpdate.encode(state, m.bitfield)
+    const s = state.start++
+    let flags = 0
+
+    if (m.userData) {
+      flags |= 1
+      keyValue.encode(state, m.userData)
+    }
+    if (m.treeNodes) {
+      flags |= 2
+      nodeArray.encode(state, m.treeNodes)
+    }
+    if (m.treeUpgrade) {
+      flags |= 4
+      treeUpgrade.encode(state, m.treeUpgrade)
+    }
+    if (m.bitfield) {
+      flags |= 8
+      bitfieldUpdate.encode(state, m.bitfield)
+    }
+
+    state.buffer[s] = flags
   },
   decode (state) {
     const flags = c.uint.decode(state)


### PR DESCRIPTION
There was a bit of inconsistency in how flags were encoded/decoded in the protocol messages. The prevalent, and arguably more readable, pattern is now used consistently.