### PR TITLE
Output replication errors as TAP comments and add `eventFlush()` helper

### DIFF
--- a/test/extension.js
+++ b/test/extension.js
@@ -1,5 +1,5 @@
 const test = require('brittle')
-const { create, replicate, tick } = require('./helpers')
+const { create, replicate, eventFlush } = require('./helpers')
 
 test('basic extension', async function (t) {
   const messages = ['world', 'hello']
@@ -20,13 +20,13 @@ test('basic extension', async function (t) {
 
   replicate(a, b, t)
 
-  await tick()
+  await eventFlush()
   t.is(b.peers.length, 1)
 
   bExt.send('hello', b.peers[0])
   bExt.send('world', b.peers[0])
 
-  await tick()
+  await eventFlush()
   t.absent(messages.length)
 
   t.end()
@@ -47,12 +47,12 @@ test('two extensions', async function (t) {
     encoding: 'utf-8'
   })
 
-  await tick()
+  await eventFlush()
   t.is(b.peers.length, 1)
 
   bExt2.send('world', b.peers[0])
 
-  await tick()
+  await eventFlush()
 
   a.registerExtension('test-extension-2', {
     encoding: 'utf-8',
@@ -64,7 +64,7 @@ test('two extensions', async function (t) {
 
   bExt2.send('hello', b.peers[0])
 
-  await tick()
+  await eventFlush()
   t.is(messages.length, 1) // First message gets ignored
 
   t.end()

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -17,7 +17,7 @@ module.exports = {
     return [s1, s2]
   },
 
-  async tick () {
+  async eventFlush () {
     await new Promise(resolve => setImmediate(resolve))
   }
 }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1,6 +1,6 @@
 const test = require('brittle')
 const NoiseSecretStream = require('noise-secret-stream')
-const { create, replicate, tick } = require('./helpers')
+const { create, replicate, eventFlush } = require('./helpers')
 
 test('basic replication', async function (t) {
   const a = await create()
@@ -227,7 +227,7 @@ test('async multiplexing', async function (t) {
 
   // b2 doesn't replicate immediately.
   a2.replicate(a)
-  await tick()
+  await eventFlush()
   b2.replicate(b)
 
   await new Promise(resolve => b2.once('peer-add', resolve))


### PR DESCRIPTION
`await new Promise(resolve => setImmediate(resolve))` was showing up quite often in tests and has now been reduced to `await eventFlush()`. Also, replication errors were being written to stdout, which broke the TAP stream. The errors are now instead printed as TAP comments.