### PR TITLE
Adding temporary stream extension destroy

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -12,21 +12,32 @@ class Extension {
     this.peers = new Set()
     this.aliased = !!handlers.aliased
     this.remoteSupports = false
+    this.destroyed = false
+
+    this.onerror = handlers.onerror || noop
+    this.onclose = handlers.onclose || noop
     this.onmessage = handlers.onmessage || noop
     this.onremotesupports = handlers.onremotesupports || noop
+
     this.encoding = fromEncoding(codecs(handlers.encoding || 'binary'))
     this.announce()
   }
 
   announce () {
+    if (this.destroyed) return
+
     this.protocol.send(1, messages.extension, -1, { alias: this.type, name: this.name })
   }
 
   send (message) {
+    if (this.destroyed) return
+
     return this._sendAlias(message, -1)
   }
 
   _sendAlias (message, alias) {
+    if (this.destroyed) return
+
     if (this._remoteAliases) {
       return this.protocol.send(this.type, this.encoding, alias, message)
     }
@@ -40,6 +51,8 @@ class Extension {
   }
 
   _onremotesupports () {
+    if (this.destroyed) return
+
     this.remoteSupports = true
     this.onremotesupports(this)
     for (const peer of this.peers) {
@@ -48,6 +61,8 @@ class Extension {
   }
 
   _onmessage (state) {
+    if (this.destroyed) return
+
     if (!this.aliased) {
       this.onmessage(this.encoding.decode(state))
       return
@@ -61,6 +76,13 @@ class Extension {
         peer.onmessage(m, peer.peer)
       }
     }
+  }
+
+  destroy () {
+    if (this.destroyed) return
+    this.destroyed = true
+    this.protocol.unregisterExtension(this.name)
+    this.onclose()
   }
 }
 
@@ -287,6 +309,14 @@ module.exports = class Protocol {
     return ext
   }
 
+  unregisterExtension (name) {
+    const ext = this._extensions.get(name)
+    if (!ext) return
+    if (!ext.destroyed) return ext.destroy()
+    this._extensions.delete(name)
+    this._remoteExtensions[ext.type - 128] = null
+  }
+
   cork () {
     if (++this._corks === 1) this._batch = []
   }
@@ -383,15 +413,12 @@ module.exports = class Protocol {
       const remoteAlias = uint.decode(state)
       const peer = this._remoteAliases[remoteAlias]
       if (peer) peer.onmessage(type, state)
-      else state.start = state.end
-      return
-    }
-
-    if (type >= 128) {
+    } else if (type >= 128) {
       const ext = this._remoteExtensions[type - 128]
       if (ext) ext._onmessage(state)
-      else state.start = state.end
     }
+
+    state.start = state.end
   }
 
   _onextension (m) {


### PR DESCRIPTION
This is a temporary fix for stream extensions lacking a `destroy` method.