### PR TITLE
Refactor session open flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,9 +183,7 @@ module.exports = class Hypercore extends EventEmitter {
       // Only the root session should pass capabilities to other sessions.
       for (let i = 0; i < this.sessions.length; i++) {
         const s = this.sessions[i]
-        if (s !== this) {
-          s._passCapabilities(this)
-        }
+        if (s !== this) s._passCapabilities(this)
       }
     }
 
@@ -196,6 +194,8 @@ module.exports = class Hypercore extends EventEmitter {
       this.valueEncoding = c.from(codecs(opts.valueEncoding))
     }
 
+    // This is a hidden option that's only used by Corestore.
+    // It's required so that corestore can load a name from userData before 'ready' is emitted.
     if (opts._preready) await opts._preready(this)
 
     this.opened = true

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.autoClose = !!opts.autoClose
 
     this.closing = null
-    this.opening = opts._opening || this._open(key, storage, opts)
+    this.opening = this._sessionOpen(key, storage, opts)
     this.opening.catch(noop)
 
     this._preappend = preappend.bind(this)
@@ -115,28 +115,20 @@ module.exports = class Hypercore extends EventEmitter {
     }
 
     const Clz = opts.class || Hypercore
-    const keyPair = opts.keyPair && opts.keyPair.secretKey && { ...opts.keyPair }
-
-    // This only works if the hypercore was fully loaded,
-    // but we only do this to validate the keypair to help catch bugs so yolo
-    if (this.key && keyPair) keyPair.publicKey = this.key
-
     const s = new Clz(this.storage, this.key, {
       ...opts,
-      sign: opts.sign || (keyPair && keyPair.secretKey && Core.createSigner(this.crypto, keyPair)) || this.sign,
-      valueEncoding: this.valueEncoding,
       extensions: this.extensions,
       _opening: this.opening,
       _sessions: this.sessions
     })
 
-    s._initSession(this)
+    s._passCapabilities(this)
     this.sessions.push(s)
 
     return s
   }
 
-  _initSession (o) {
+  _passCapabilities (o) {
     if (!this.sign) this.sign = o.sign
     this.crypto = o.crypto
     this.opened = o.opened
@@ -147,6 +139,98 @@ module.exports = class Hypercore extends EventEmitter {
     this.encryption = o.encryption
     this.writable = !!this.sign
     this.autoClose = o.autoClose
+  }
+
+  async _openFromExisting (from, opts) {
+    await from.opening
+
+    for (const [name, ext] of this.extensions) {
+      from.extensions.register(name, null, ext)
+    }
+
+    this._passCapabilities(from)
+    this.extensions = from.extensions
+    this.sessions = from.sessions
+    this.storage = from.storage
+
+    this.sessions.push(this)
+  }
+
+  async _sessionOpen (key, storage, opts) {
+    const isRoot = !opts._opening
+
+    if (!isRoot) await opts._opening
+    if (opts.preload) opts = { ...opts, ...(await opts.preload()) }
+
+    const keyPair = (key && opts.keyPair)
+      ? { ...opts.keyPair, publicKey: key }
+      : key
+        ? { publicKey: key, secretKey: null }
+        : opts.keyPair
+
+    // This only works if the hypercore was fully loaded,
+    // but we only do this to validate the keypair to help catch bugs so yolo
+    if (this.key && keyPair) keyPair.publicKey = this.key
+
+    if (opts.sign) {
+      this.sign = opts.sign
+    } else if (keyPair && keyPair.secretKey) {
+      this.sign = Core.createSigner(this.crypto, keyPair)
+    }
+
+    if (isRoot) {
+      await this._rootOpen(keyPair, storage, opts)
+      // Only the root session should pass capabilities to other sessions.
+      for (let i = 0; i < this.sessions.length; i++) {
+        const s = this.sessions[i]
+        if (s !== this) {
+          s._passCapabilities(this)
+        }
+      }
+    }
+
+    if (!this.sign) this.sign = this.core.defaultSign
+    this.writable = !!this.sign
+
+    if (opts.valueEncoding) {
+      this.valueEncoding = c.from(codecs(opts.valueEncoding))
+    }
+
+    if (opts.postload) await opts.postload(this)
+
+    this.emit('ready')
+    this.opened = true
+  }
+
+  async _rootOpen (keyPair, storage, opts) {
+    if (opts.from) return this._openFromExisting(opts.from, opts)
+
+    if (!this.storage) this.storage = Hypercore.defaultStorage(opts.storage || storage)
+
+    this.core = await Core.open(this.storage, {
+      keyPair,
+      crypto: this.crypto,
+      onupdate: this._oncoreupdate.bind(this)
+    })
+
+    if (opts.userData) {
+      for (const [key, value] of Object.entries(opts.userData)) {
+        await this.core.userData(key, value)
+      }
+    }
+
+    this.replicator = new Replicator(this.core, {
+      onupdate: this._onpeerupdate.bind(this)
+    })
+
+    this.discoveryKey = this.crypto.discoveryKey(this.core.header.signer.publicKey)
+    this.key = this.core.header.signer.publicKey
+
+    if (!this.encryption && opts.encryptionKey) {
+      this.encryption = new BlockEncryption(opts.encryptionKey, this.key)
+    }
+
+    this.extensions.attach(this.replicator)
   }
 
   close () {
@@ -235,71 +319,6 @@ module.exports = class Hypercore extends EventEmitter {
 
   ready () {
     return this.opening
-  }
-
-  async _open (key, storage, opts) {
-    if (opts.preload) opts = { ...opts, ...(await opts.preload()) }
-
-    this.valueEncoding = opts.valueEncoding ? c.from(codecs(opts.valueEncoding)) : null
-
-    const keyPair = (key && opts.keyPair)
-      ? { ...opts.keyPair, publicKey: key }
-      : key
-        ? { publicKey: key, secretKey: null }
-        : opts.keyPair
-
-    if (opts.from) {
-      const from = opts.from
-      await from.opening
-      for (const [name, ext] of this.extensions) from.extensions.register(name, null, ext)
-      this._initSession(from)
-      this.extensions = from.extensions
-      this.sessions = from.sessions
-      this.storage = from.storage
-      if (!this.sign) this.sign = opts.sign || ((keyPair && keyPair.secretKey) ? Core.createSigner(this.crypto, keyPair) : null)
-      this.writable = !!this.sign
-      this.sessions.push(this)
-      return
-    }
-
-    if (!this.storage) this.storage = Hypercore.defaultStorage(opts.storage || storage)
-
-    this.core = await Core.open(this.storage, {
-      keyPair,
-      crypto: this.crypto,
-      onupdate: this._oncoreupdate.bind(this)
-    })
-
-    if (opts.userData) {
-      for (const [key, value] of Object.entries(opts.userData)) {
-        await this.core.userData(key, value)
-      }
-    }
-
-    this.replicator = new Replicator(this.core, {
-      onupdate: this._onpeerupdate.bind(this)
-    })
-
-    if (!this.sign) this.sign = opts.sign || this.core.defaultSign
-
-    this.discoveryKey = this.crypto.discoveryKey(this.core.header.signer.publicKey)
-    this.key = this.core.header.signer.publicKey
-    this.writable = !!this.sign
-
-    if (!this.encryption && opts.encryptionKey) {
-      this.encryption = new BlockEncryption(opts.encryptionKey, this.key)
-    }
-
-    this.extensions.attach(this.replicator)
-    this.opened = true
-
-    if (opts.postload) await opts.postload(this)
-
-    for (let i = 0; i < this.sessions.length; i++) {
-      const s = this.sessions[i]
-      if (s !== this) s._initSession(this)
-      s.emit('ready')
-    }
   }
 
   _oncoreupdate (status, bitfield, value, from) {

--- a/index.js
+++ b/index.js
@@ -157,9 +157,9 @@ module.exports = class Hypercore extends EventEmitter {
   }
 
   async _openSession (key, storage, opts) {
-    const isRoot = !opts._opening
+    const isFirst = !opts._opening
 
-    if (!isRoot) await opts._opening
+    if (!isFirst) await opts._opening
     if (opts.preload) opts = { ...opts, ...(await opts.preload()) }
 
     const keyPair = (key && opts.keyPair)
@@ -178,8 +178,8 @@ module.exports = class Hypercore extends EventEmitter {
       this.sign = Core.createSigner(this.crypto, keyPair)
     }
 
-    if (isRoot) {
-      await this._openRoot(keyPair, storage, opts)
+    if (isFirst) {
+      await this._openCapabilities(keyPair, storage, opts)
       // Only the root session should pass capabilities to other sessions.
       for (let i = 0; i < this.sessions.length; i++) {
         const s = this.sessions[i]
@@ -202,7 +202,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.emit('ready')
   }
 
-  async _openRoot (keyPair, storage, opts) {
+  async _openCapabilities (keyPair, storage, opts) {
     if (opts.from) return this._openFromExisting(opts.from, opts)
 
     if (!this.storage) this.storage = Hypercore.defaultStorage(opts.storage || storage)

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.autoClose = !!opts.autoClose
 
     this.closing = null
-    this.opening = this._sessionOpen(key, storage, opts)
+    this.opening = this._openSession(key, storage, opts)
     this.opening.catch(noop)
 
     this._preappend = preappend.bind(this)
@@ -156,7 +156,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.sessions.push(this)
   }
 
-  async _sessionOpen (key, storage, opts) {
+  async _openSession (key, storage, opts) {
     const isRoot = !opts._opening
 
     if (!isRoot) await opts._opening
@@ -179,7 +179,7 @@ module.exports = class Hypercore extends EventEmitter {
     }
 
     if (isRoot) {
-      await this._rootOpen(keyPair, storage, opts)
+      await this._openRoot(keyPair, storage, opts)
       // Only the root session should pass capabilities to other sessions.
       for (let i = 0; i < this.sessions.length; i++) {
         const s = this.sessions[i]
@@ -202,7 +202,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.emit('ready')
   }
 
-  async _rootOpen (keyPair, storage, opts) {
+  async _openRoot (keyPair, storage, opts) {
     if (opts.from) return this._openFromExisting(opts.from, opts)
 
     if (!this.storage) this.storage = Hypercore.defaultStorage(opts.storage || storage)

--- a/index.js
+++ b/index.js
@@ -196,10 +196,10 @@ module.exports = class Hypercore extends EventEmitter {
       this.valueEncoding = c.from(codecs(opts.valueEncoding))
     }
 
-    if (opts.postload) await opts.postload(this)
+    if (opts._preready) await opts._preready(this)
 
-    this.emit('ready')
     this.opened = true
+    this.emit('ready')
   }
 
   async _rootOpen (keyPair, storage, opts) {

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -15,6 +15,7 @@ test('sessions - can create writable sessions from a read-only core', async func
   t.absent(core.writable)
 
   const session = core.session({ keyPair: { secretKey: keyPair.secretKey } })
+  await session.ready()
   t.ok(session.writable)
 
   try {
@@ -74,7 +75,8 @@ test('sessions - writable session with invalid keypair throws', async function (
 
   try {
     const core = new Hypercore(ram, keyPair2.publicKey) // Create a new core in read-only mode.
-    core.session({ keyPair: keyPair1 })
+    const session = core.session({ keyPair: keyPair1 })
+    await session.ready()
     t.fail('invalid keypair did not throw')
   } catch {
     t.pass('invalid keypair threw')
@@ -170,4 +172,12 @@ test('sessions - close with from option', async function (t) {
 
   t.absent(core1.closed)
   t.alike(await core1.get(0), Buffer.from('hello world'))
+})
+
+test('sessions - custom valueEncoding on session', async function (t) {
+  const core1 = new Hypercore(ram)
+  const core2 = core1.session({ valueEncoding: 'utf-8' })
+
+  await core1.append(Buffer.from('hello world'))
+  t.is(await core2.get(0), 'hello world')
 })


### PR DESCRIPTION
The current session open flow will not support passing sessions `preload` or `valueEncoding` options.
 
With this new approach, the storage opening is extracted into a `_openCapabilities` method that's only called by the first session. All sessions are opened with a `_openSession` method, which waits on the capabilities opening Promise.

As part of this, I also cleaned up some of the opening flow and added another session test. The session tests were making assumptions about sessions that break parity with normal Hypercore:
1. `session.writable` should only be readable after `session.ready()` resolves
2. `core.session()` should not synchronously throw on errors that would typically be thrown in `core.ready()`

This PR  changes those behaviors for consistency.

One final thing: corestore@next has been depending on the `postload` option, which we didn't think through. A better approach is to have a hidden option `_preready` for the Corestore use-case, as nobody else should need this feature (it's very opaque).