### PR TITLE
Fix: Use the remoteAlias when sending an extension message

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -106,7 +106,7 @@ class CoreExtension {
   }
 
   send (message) {
-    return this.extension._sendAlias(message, this.peer.alias)
+    return this.extension._sendAlias(message, this.peer.remoteAlias)
   }
 
   destroy () {


### PR DESCRIPTION
Messages weren't getting delivered when I tried using an extension. I tracked it down to the sent alias being incorrect [here](https://github.com/hypercore-protocol/hypercore-next/blob/extension-alias/lib/protocol.js#L75-L80). This PR fixes that by using `remoteAlias` on [send](https://github.com/hypercore-protocol/hypercore-next/blob/extension-alias/lib/protocol.js#L109).

I'm unsure why the repo's tests didn't expose this bug previously; the extensions code is a bit complex right now. In my repo, I'm using corestore's replicate rather than directly calling replicate on the cores, so perhaps that changes the code path?

I also noticed that `this._remoteAliases` is being checked [here](https://github.com/hypercore-protocol/hypercore-next/blob/extension-alias/lib/protocol.js#L42) but I dont think the `Extension` class will ever have that set. That might need to be `this.protocol._remoteAliases`?
