### PR TITLE
Add encodeBatch constructor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,15 @@ Note that `tree`, `data`, and `bitfield` are normally heavily sparse files.
   createIfMissing: true, // create a new Hypercore key pair if none was present in storage
   overwrite: false, // overwrite any old Hypercore that might already exist
   valueEncoding: 'json' | 'utf-8' | 'binary', // defaults to binary
+  encodeBatch: batch => { ... }, // optionally apply an encoding to complete batches
   keyPair: kp, // optionally pass the public key and secret key as a key pair
   encryptionKey: k // optionally pass an encryption key to enable block encryption
 }
 ```
 
 You can also set valueEncoding to any [abstract-encoding](https://github.com/mafintosh/abstract-encoding) or [compact-encoding](https://github.com/compact-encoding) instance.
+
+valueEncodings will be applied to individually blocks, even if you append batches. If you want to control encoding at the batch-level, you can use the `encodeBatch` option.
 
 #### `const seq = await core.append(block)`
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note that `tree`, `data`, and `bitfield` are normally heavily sparse files.
 
 You can also set valueEncoding to any [abstract-encoding](https://github.com/mafintosh/abstract-encoding) or [compact-encoding](https://github.com/compact-encoding) instance.
 
-valueEncodings will be applied to individually blocks, even if you append batches. If you want to control encoding at the batch-level, you can use the `encodeBatch` option.
+valueEncodings will be applied to individually blocks, even if you append batches. If you want to control encoding at the batch-level, you can use the `encodeBatch` option, which is a function that takes a batch and returns a binary-encoded batch. If you provide a custom valueEncoding, it will not be applied prior to `encodeBatch`.
 
 #### `const seq = await core.append(block)`
 

--- a/index.js
+++ b/index.js
@@ -486,9 +486,9 @@ module.exports = class Hypercore extends EventEmitter {
 
     const preappend = this.encryption && this._preappend
 
-    const buffers = this.encodeBatch ? this.encodeBatch(blocks) : new Array(blocks.length)
+    const buffers = this.encodeBatch !== null ? this.encodeBatch(blocks) : new Array(blocks.length)
 
-    if (!this.encodeBatch) {
+    if (this.encodeBatch === null) {
       for (let i = 0; i < blocks.length; i++) {
         buffers[i] = this._encode(this.valueEncoding, blocks[i])
       }

--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ module.exports = class Hypercore extends EventEmitter {
     this.cache = opts.cache === true ? new Xache({ maxSize: 65536, maxAge: 0 }) : (opts.cache || null)
 
     this.valueEncoding = null
+    this.encodeBatch = null
+
     this.key = key || null
     this.discoveryKey = null
     this.readable = true
@@ -191,6 +193,9 @@ module.exports = class Hypercore extends EventEmitter {
 
     if (opts.valueEncoding) {
       this.valueEncoding = c.from(codecs(opts.valueEncoding))
+    }
+    if (opts.encodeBatch) {
+      this.encodeBatch = opts.encodeBatch
     }
 
     // This is a hidden option that's only used by Corestore.
@@ -480,10 +485,13 @@ module.exports = class Hypercore extends EventEmitter {
     blocks = Array.isArray(blocks) ? blocks : [blocks]
 
     const preappend = this.encryption && this._preappend
-    const buffers = new Array(blocks.length)
 
-    for (let i = 0; i < blocks.length; i++) {
-      buffers[i] = this._encode(this.valueEncoding, blocks[i])
+    const buffers = this.encodeBatch ? this.encodeBatch(blocks) : new Array(blocks.length)
+
+    if (!this.encodeBatch) {
+      for (let i = 0; i < blocks.length; i++) {
+        buffers[i] = this._encode(this.valueEncoding, blocks[i])
+      }
     }
 
     return await this.core.append(buffers, this.sign, { preappend })

--- a/test/encodings.js
+++ b/test/encodings.js
@@ -16,3 +16,19 @@ test('encodings - supports custom encoding', async function (t) {
   t.is(await a.get(0), 'bar')
   t.alike(await a.get(0, { valueEncoding: 'utf-8' }), 'foo')
 })
+
+test('encodings - supports custom batch encoding', async function (t) {
+  const a = await create(null, {
+    encodeBatch: batch => {
+      return [Buffer.from(batch.map(b => b.toString()).join('-'))]
+    },
+    valueEncoding: 'utf-8'
+  })
+  await a.append(['a', 'b', 'c'])
+  await a.append(['d', 'e'])
+  await a.append('f')
+
+  t.is(await a.get(0), 'a-b-c')
+  t.is(await a.get(1), 'd-e')
+  t.is(await a.get(2), 'f')
+})


### PR DESCRIPTION
`valueEncoding` is applied to individual blocks during batch appends (`core.append([b1, b2, b3])`). The `encodeBatch` option is a function that's passed complete batches, and must return a binary-encoded batch.