### PR TITLE
Implement wait get option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Options include
 
 ``` js
 {
-  wait: true, // wait for index to be downloaded
+  wait: true, // wait for block to be downloaded
   onwait: () => {}, // hook that is called if the get is waiting for download
   timeout: 0, // wait at max some milliseconds (0 means no timeout)
   valueEncoding: 'json' | 'utf-8' | 'binary' // defaults to the core's valueEncoding

--- a/index.js
+++ b/index.js
@@ -416,6 +416,7 @@ module.exports = class Hypercore extends EventEmitter {
     if (this.core.bitfield.get(index)) {
       block = await this.core.blocks.get(index)
     } else {
+      if (opts && opts.wait === false) return null
       if (opts && opts.onwait) opts.onwait(index)
       block = await this.replicator.requestBlock(index)
     }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -370,3 +370,16 @@ test('replicate discrete empty range', async function (t) {
 
   t.is(d, 0)
 })
+
+test('get with { wait: false } returns null if block is not available', async function (t) {
+  const a = await create()
+
+  await a.append('a')
+
+  const b = await create(a.key, { valueEncoding: 'utf-8' })
+
+  replicate(a, b, t)
+
+  t.is(await b.get(0, { wait: false }), null)
+  t.is(await b.get(0), 'a')
+})


### PR DESCRIPTION
This PR implements the `wait` option for `core.get`, which will force `get` to return `null` if the block is not available locally.