### PR TITLE
Pass replication options to Replicator

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = class Hypercore extends EventEmitter {
     if (!noiseStream) throw new Error('Invalid stream')
 
     if (!noiseStream.userData) {
-      const protocol = Replicator.createProtocol(noiseStream)
+      const protocol = Replicator.createProtocol(noiseStream, opts)
       if (opts.keepAlive !== false) protocol.setKeepAlive(true)
       noiseStream.userData = protocol
       noiseStream.on('error', noop) // All noise errors already propagate through outerStream

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -633,8 +633,9 @@ module.exports = class Replicator {
     this.onupdate = onupdate
   }
 
-  static createProtocol (noiseStream) {
+  static createProtocol (noiseStream, opts) {
     return new Protocol(noiseStream, {
+      ...opts,
       protocolVersion: 0,
       userAgent: USER_AGENT
     })


### PR DESCRIPTION
Corestore has one `ondiscoverykey` hook that's passed to a top-level protocol stream, and that hook needs to be passed into the replicator.