### PR TITLE
Use `turbo-hash-map` to avoid stringifying keys

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -3,6 +3,7 @@ const b4a = require('b4a')
 const safetyCatch = require('safety-catch')
 const codecs = require('codecs')
 const sodium = require('sodium-universal')
+const HashMap = require('turbo-hash-map')
 
 const messages = require('./messages')
 
@@ -284,7 +285,7 @@ module.exports = class Protocol {
 
     this._localAliases = 0
     this._remoteAliases = []
-    this._peers = new Map()
+    this._peers = new HashMap()
 
     this._localExtensions = 128
     this._remoteExtensions = []
@@ -332,18 +333,18 @@ module.exports = class Protocol {
   }
 
   isRegistered (discoveryKey) {
-    return this._peers.has(discoveryKey.toString('hex'))
+    return this._peers.has(discoveryKey)
   }
 
   registerPeer (key, discoveryKey, handlers = {}, state = null) {
     const peer = new Peer(this, this._localAliases++, key, discoveryKey, handlers, state)
-    this._peers.set(b4a.toString(discoveryKey, 'hex'), peer)
+    this._peers.set(discoveryKey, peer)
     this._announceCore(peer.alias, key, discoveryKey)
     return peer
   }
 
   unregisterPeer (peer, err) {
-    this._peers.delete(b4a.toString(peer.discoveryKey, 'hex'))
+    this._peers.delete(peer.discoveryKey)
 
     if (peer.remoteAlias > -1) {
       this._remoteAliases[peer.remoteAlias] = null
@@ -510,8 +511,7 @@ module.exports = class Protocol {
   }
 
   _oncore (m) {
-    const hex = b4a.toString(m.discoveryKey, 'hex')
-    const peer = this._peers.get(hex)
+    const peer = this._peers.get(m.discoveryKey)
 
     // allow one alloc
     // TODO: if the remote allocs too many "holes", move to slower sparse firendly
@@ -544,13 +544,13 @@ module.exports = class Protocol {
     else next()
 
     function next () {
-      if (self._peers.has(hex)) return self._oncore(m)
+      if (self._peers.has(m.discoveryKey)) return self._oncore(m)
       self.send(3, messages.unknownCore, -1, { discoveryKey: m.discoveryKey })
     }
   }
 
   _onunknowncore (m) {
-    const peer = this._peers.get(b4a.toString(m.discoveryKey, 'hex'))
+    const peer = this._peers.get(m.discoveryKey)
     if (!peer) return
 
     peer.resend = true

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",
     "sodium-universal": "^3.0.4",
+    "turbo-hash-map": "^1.0.2",
     "xache": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Depends on https://github.com/mafintosh/turbo-hash-map/pull/3 to maintain browser compatibility.