### PR TITLE
set `opened=false` in `_close()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,6 +282,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.readable = false
     this.writable = false
     this.closed = true
+    this.opened = false
 
     if (this.sessions.length) {
       // if this is the last session and we are auto closing, trigger that first to enforce error handling


### PR DESCRIPTION
On the current master branch, a closed hypercore will still display `opened=true` in addition to `closed=true`. This PR sets the `opened` property to `false`, which resolves the issue for me.