### PR TITLE
Adjust error message format and improve stack traces

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,7 +1,16 @@
 module.exports = class HypercoreError extends Error {
   constructor (msg, code) {
-    super(msg)
+    super(`${code}: ${msg}`)
     this.code = code
+
+    if (Error.captureStackTrace) {
+      const ctor = this.constructor
+      Error.captureStackTrace(this, ctor[code] || ctor)
+    }
+  }
+
+  get name () {
+    return 'HypercoreError'
   }
 
   static BAD_ARGUMENT (msg) {


### PR DESCRIPTION
```sh
# master
> HypercoreError.BAD_ARGUMENT('Invalid key pair')
HypercoreError: Invalid key pair
    at Function.BAD_ARGUMENT (lib/errors.js:8:12)
    at REPL2:1:16
    at Script.runInThisContext (node:vm:129:12)
    at REPLServer.defaultEval (node:repl:566:29)
    at bound (node:domain:421:15)
    at REPLServer.runBound [as eval] (node:domain:432:12)
    at REPLServer.onLine (node:repl:893:10)
    at REPLServer.emit (node:events:539:35)
    at REPLServer.emit (node:domain:475:12)
    at REPLServer.[_onLine] [as _onLine] (node:internal/readline/interface:418:12) {
  code: 'BAD_ARGUMENT'
}
```

```sh
# error-tweaks
> HypercoreError.BAD_ARGUMENT('Invalid key pair')
HypercoreError: BAD_ARGUMENT: Invalid key pair
    at REPL2:1:16
    at Script.runInThisContext (node:vm:129:12)
    at REPLServer.defaultEval (node:repl:566:29)
    at bound (node:domain:421:15)
    at REPLServer.runBound [as eval] (node:domain:432:12)
    at REPLServer.onLine (node:repl:893:10)
    at REPLServer.emit (node:events:539:35)
    at REPLServer.emit (node:domain:475:12)
    at REPLServer.[_onLine] [as _onLine] (node:internal/readline/interface:418:12)
    at REPLServer.[_line] [as _line] (node:internal/readline/interface:879:18) {
  code: 'BAD_ARGUMENT'
}
```

The changes are also reflected in `err.toString()`:

```sh
# master
> HypercoreError.BAD_ARGUMENT('Invalid key pair').toString()
'Error: Invalid key pair'
```

```sh
# error-tweaks
> HypercoreError.BAD_ARGUMENT('Invalid key pair').toString()
'HypercoreError: BAD_ARGUMENT: Invalid key pair'
```