### PR TITLE
feat(oplog): add encryptionKey to oplog.header

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,6 +284,7 @@ module.exports = class Hypercore extends EventEmitter {
       crypto: this.crypto,
       legacy: opts.legacy,
       auth: opts.auth,
+      encryptionKey: opts.encryptionKey,
       onupdate: this._oncoreupdate.bind(this)
     })
 
@@ -305,8 +306,8 @@ module.exports = class Hypercore extends EventEmitter {
 
     this.replicator.findingPeers += this._findingPeers
 
-    if (!this.encryption && opts.encryptionKey) {
-      this.encryption = new BlockEncryption(opts.encryptionKey, this.key)
+    if (!this.encryption && this.core.header.encryptionKey) {
+      this.encryption = new BlockEncryption(this.core.header.encryptionKey, this.key)
     }
   }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -106,7 +106,8 @@ module.exports = class Core {
         signer: opts.keyPair || crypto.keyPair(),
         hints: {
           reorgs: []
-        }
+        },
+        encryptionKey: opts.encryptionKey
       }
 
       await oplog.flush(header)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -622,6 +622,7 @@ oplog.header = {
     treeHeader.preencode(state, h.tree)
     keyPair.preencode(state, h.signer)
     hints.preencode(state, h.hints)
+    c.buffer.preencode(state, h.encryptionKey)
   },
   encode (state, h) {
     state.buffer[state.start++] = 0 // version
@@ -630,6 +631,7 @@ oplog.header = {
     treeHeader.encode(state, h.tree)
     keyPair.encode(state, h.signer)
     hints.encode(state, h.hints)
+    c.buffer.encode(state, h.encryptionKey)
   },
   decode (state) {
     const version = c.uint.decode(state)
@@ -643,7 +645,8 @@ oplog.header = {
       userData: keyValueArray.decode(state),
       tree: treeHeader.decode(state),
       signer: keyPair.decode(state),
-      hints: hints.decode(state)
+      hints: hints.decode(state),
+      encryptionKey: c.buffer.decode(state)
     }
   }
 }


### PR DESCRIPTION
add encryptionKey to oplog.header to correctly open encrypted cores from
storage

Closes #95 and fixes https://github.com/hypercore-protocol/corestore-next/issues/14, and removes the need for https://github.com/hypercore-protocol/corestore-next/pull/15