### PR TITLE
Add `core.contiguousLength`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ How much data is available on this core in bytes?
 
 Populated after `ready` has been emitted. Will be `0` before the event.
 
+#### `core.contiguousLength`
+
+How many blocks are contiguously available starting from the first block of this core?
+
+Populated after `ready` has been emitted. Will be `0` before the event.
+
 #### `core.fork`
 
 What is the current fork id of this core?

--- a/index.js
+++ b/index.js
@@ -414,6 +414,10 @@ module.exports = class Hypercore extends EventEmitter {
       : (this.core === null ? 0 : this.core.tree.byteLength - (this.core.tree.length * this.padding))
   }
 
+  get contiguousLength () {
+    return this.core === null ? 0 : this.core.header.contiguousLength
+  }
+
   get fork () {
     return this.core === null ? 0 : this.core.tree.fork
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -106,7 +106,8 @@ module.exports = class Core {
         signer: opts.keyPair || crypto.keyPair(),
         hints: {
           reorgs: []
-        }
+        },
+        contiguousLength: 0
       }
 
       await oplog.flush(header)
@@ -192,6 +193,16 @@ module.exports = class Core {
     await this.blocks.put(index, value, byteOffset)
   }
 
+  _updateContiguousLength (bitfield) {
+    if (bitfield.start === this.header.contiguousLength) {
+      let i = this.header.contiguousLength + bitfield.length
+
+      while (this.bitfield.get(i)) i++
+
+      this.header.contiguousLength = i
+    }
+  }
+
   async userData (key, value) {
     // TODO: each oplog append can set user data, so we should have a way
     // to just hitch a ride on one of the other ongoing appends?
@@ -271,6 +282,7 @@ module.exports = class Core {
       this.bitfield.setRange(batch.ancestors, batch.length - batch.ancestors, true)
       batch.commit()
 
+      this.header.contiguousLength = batch.length
       this.header.tree.length = batch.length
       this.header.tree.rootHash = hash
       this.header.tree.signature = batch.signature
@@ -312,7 +324,11 @@ module.exports = class Core {
 
       await this.oplog.append([entry], false)
 
-      if (bitfield) this.bitfield.set(bitfield.start, true)
+      if (bitfield) {
+        this.bitfield.set(bitfield.start, true)
+        this._updateContiguousLength(bitfield)
+      }
+
       batch.commit()
 
       this.header.tree.fork = batch.fork
@@ -366,8 +382,13 @@ module.exports = class Core {
           continue
         }
 
-        if (bitfield) this.bitfield.set(bitfield.start, true)
+        if (bitfield) {
+          this.bitfield.set(bitfield.start, true)
+          this._updateContiguousLength(bitfield)
+        }
+
         batch.commit()
+
         this.onupdate(0, bitfield, value, from)
       }
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -622,6 +622,7 @@ oplog.header = {
     treeHeader.preencode(state, h.tree)
     keyPair.preencode(state, h.signer)
     hints.preencode(state, h.hints)
+    c.uint.preencode(state, h.contiguousLength)
   },
   encode (state, h) {
     state.buffer[state.start++] = 0 // version
@@ -630,6 +631,7 @@ oplog.header = {
     treeHeader.encode(state, h.tree)
     keyPair.encode(state, h.signer)
     hints.encode(state, h.hints)
+    c.uint.encode(state, h.contiguousLength)
   },
   decode (state) {
     const version = c.uint.decode(state)
@@ -643,7 +645,8 @@ oplog.header = {
       userData: keyValueArray.decode(state),
       tree: treeHeader.decode(state),
       signer: keyPair.decode(state),
-      hints: hints.decode(state)
+      hints: hints.decode(state),
+      contiguousLength: c.uint.decode(state)
     }
   }
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,38 +1,36 @@
 const Hypercore = require('../../')
 const ram = require('random-access-memory')
 
-module.exports = {
-  async create (...args) {
-    const core = new Hypercore(ram, ...args)
-    await core.ready()
-    return core
-  },
+exports.create = async function create (...args) {
+  const core = new Hypercore(ram, ...args)
+  await core.ready()
+  return core
+}
 
-  createStored () {
-    const files = new Map()
+exports.createStored = function createStored () {
+  const files = new Map()
 
-    return function (...args) {
-      return new Hypercore(storage, ...args)
-    }
-
-    function storage (name) {
-      if (files.has(name)) return files.get(name).clone()
-      const st = ram()
-      files.set(name, st)
-      return st
-    }
-  },
-
-  replicate (a, b, t) {
-    const s1 = a.replicate(true, { keepAlive: false })
-    const s2 = b.replicate(false, { keepAlive: false })
-    s1.on('error', err => t.comment(`replication stream error (initiator): ${err}`))
-    s2.on('error', err => t.comment(`replication stream error (responder): ${err}`))
-    s1.pipe(s2).pipe(s1)
-    return [s1, s2]
-  },
-
-  async eventFlush () {
-    await new Promise(resolve => setImmediate(resolve))
+  return function (...args) {
+    return new Hypercore(storage, ...args)
   }
+
+  function storage (name) {
+    if (files.has(name)) return files.get(name).clone()
+    const st = ram()
+    files.set(name, st)
+    return st
+  }
+}
+
+exports.replicate = function replicate (a, b, t) {
+  const s1 = a.replicate(true, { keepAlive: false })
+  const s2 = b.replicate(false, { keepAlive: false })
+  s1.on('error', err => t.comment(`replication stream error (initiator): ${err}`))
+  s2.on('error', err => t.comment(`replication stream error (responder): ${err}`))
+  s1.pipe(s2).pipe(s1)
+  return [s1, s2]
+}
+
+exports.eventFlush = async function eventFlush () {
+  await new Promise(resolve => setImmediate(resolve))
 }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -532,3 +532,27 @@ test.skip('can disable downloading from a peer', async function (t) {
   t.is(aUploads, 0)
   t.is(cUploads, a.length)
 })
+
+test('contiguous length', async function (t) {
+  const a = await create()
+
+  await a.append(['a', 'b', 'c', 'd', 'e'])
+  t.is(a.contiguousLength, 5)
+
+  const b = await create(a.key)
+  t.is(b.contiguousLength, 0)
+
+  let d = 0
+  b.on('download', () => d++)
+
+  replicate(a, b, t)
+
+  await b.download({ blocks: [0, 2, 4] }).downloaded()
+  t.is(b.contiguousLength, 1, 'has 0 through 1')
+
+  await b.download({ blocks: [1] }).downloaded()
+  t.is(b.contiguousLength, 3, 'has 0 through 2')
+
+  await b.download({ blocks: [3] }).downloaded()
+  t.is(b.contiguousLength, 5, 'has 0 through 4')
+})


### PR DESCRIPTION
This PR adds a `core.contiguousLength` property, stored in the oplog header, that tracks the number of contiguously available blocks starting from the first block of a core.