### PR TITLE
feat(core.update()): add option to force update writable cores

### DIFF
--- a/index.js
+++ b/index.js
@@ -601,8 +601,7 @@ module.exports = class Hypercore extends EventEmitter {
     if (this.opened === false) await this.opening
     if (this.closing !== null) return false
 
-    // TODO: add an option where a writer can bootstrap it's state from the network also
-    if (this.writable) {
+    if (this.writable && !opts?.force === true) {
       if (!this.snapshotted) return false
       return this._updateSnapshot()
     }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -840,3 +840,25 @@ test('sparse replication without gossiping', async function (t) {
     t.alike(await c.seek(4), [4, 0])
   })
 })
+
+test('force update writable cores', async function (t) {
+  const a = await create()
+  const b = await create(a.key, { auth: a.auth })
+
+  await a.append(['a', 'b', 'c', 'd', 'e'])
+
+  replicate(a, b, t)
+
+  await b.update()
+
+  t.is(a.length, 5)
+  t.is(b.length, 0, "new device didn't bootstrap its state from the network")
+
+  await b.update({ force: true })
+
+  t.is(
+    b.length,
+    a.length,
+    'new device did bootstrap its state from the network'
+  )
+})


### PR DESCRIPTION
Helps for cautious restoring of Hypercores on new devices, in combination with truncation.

Admittedly for any eagerly replicated and readily seeded core, waiting for a few minutes should be enough to find the latest state, but still.